### PR TITLE
Fix a few script issues

### DIFF
--- a/update_hmda_explorer.sh
+++ b/update_hmda_explorer.sh
@@ -14,8 +14,8 @@
 #
 # Get a Census API key from: http://api.census.gov/data/key_signup.html
 #
-# This script is designed to run against the dev mongo server. Ask the Delivery 
-# Team for its address and port. You'll also need an account that's authorized 
+# This script is designed to run against the dev mongo server. Ask the Delivery
+# Team for its address and port. You'll also need an account that's authorized
 # to run aggregations and edit collections in the `hmda` database.
 #
 # You must also have GDAL, MongoDB, jq and iconv installed. On Mac OS X you can do:
@@ -112,7 +112,7 @@ mongo $reporting $MONGO_DEV_HOST:$MONGO_DEV_PORT/hmda -u $MONGO_DEV_USERNAME -p 
 check $?
 
 start "Downloading and processing state population data from the census"
-curl -s "http://api.census.gov/data/2010/sf1?key=$CENSUS_API_KEY&get=P0010001,NAME&for=state:*" | jq '.[1:] | map({population:.[0], state_name:.[1], state_code:.[2]})' > input/tmp/state-populations.json
+curl -s "https://api.census.gov/data/2010/sf1?key=$CENSUS_API_KEY&get=P0010001,NAME&for=state:*" | jq '.[1:] | map({population:.[0], state_name:.[1], state_code:.[2]})' > input/tmp/state-populations.json
 check $?
 
 start "Processing county population data from the census"
@@ -142,7 +142,7 @@ check $?
 # Now that you have a comprehensive `hmda_lar_by_county` collection, let's integrate the county shapefiles.
 
 start "Downloading and unzipping county shapefiles from the Census"
-curl -s http://www2.census.gov/geo/tiger/GENZ2016/shp/cb_2016_us_county_500k.zip | tar -xf- -C input/tmp
+curl -s https://www2.census.gov/geo/tiger/GENZ2016/shp/cb_2016_us_county_500k.zip | tar -xf- -C input/tmp
 check $?
 
 start "Converting the census' shapefile into a GeoJSON file"
@@ -178,7 +178,7 @@ if [ -f input/tmp/hmda_lar_geo.json ]; then
   println_normal "TileMill project files have been successfully generated!"
 else
   println_alert "'hmda_lar_geo.json' was not successfully created. Something went wrong!"
-fi 
+fi
 
 # All done with the map stuff. Now let's generate the JSON for the charts.
 

--- a/update_hmda_explorer.sh
+++ b/update_hmda_explorer.sh
@@ -197,8 +197,12 @@ start "Add state names to the HMDA chart records"
 ($MONGO mongo-scripts/add_state_names_to_charts.js)
 check $?
 
+# [.[] | select(.state_name)] => Make sure the array only contains objects with
+# `state_name` keys
+
 start "Exporting the JSON for chart #1"
-($MONGO_EXPORT --collection hmda_lar_by_state --jsonArray) | jq 'map(
+($MONGO_EXPORT --collection hmda_lar_by_state --jsonArray) | \
+  jq '[.[] | select(.state_name)] | map(
   {
     (.state_name): {
       name: (.state_name), data: [
@@ -212,7 +216,8 @@ start "Exporting the JSON for chart #1"
 check $?
 
 start "Exporting the JSON for chart #2"
-($MONGO_EXPORT --collection hmda_lar_by_state --jsonArray) | jq 'map(
+($MONGO_EXPORT --collection hmda_lar_by_state --jsonArray) | \
+  jq '[.[] | select(.state_name)] | map(
   {
     (.state_name): {
       name: (.state_name), data: [


### PR DESCRIPTION
While verifying the script produces the same artifacts as the 2017 release, I ran into a few errors:

1. `curl` failed to retrieve the files from the Census API
1. `jq map` was failing due to missing keys

This PR fixes those issues and returns to the state where the script can be run to completion w/o human intervention